### PR TITLE
Update updatep1

### DIFF
--- a/tools/tools/nanobsd/Files/root/updatep1
+++ b/tools/tools/nanobsd/Files/root/updatep1
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2004-2005 Poul-Henning Kamp.
 # All rights reserved.
+# Copyright 2025 Karl Denninger
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,3 +52,14 @@ dd of=/dev/${NANO_DRIVE}s1 obs=64k
 fsck_ffs -n /dev/${NANO_DRIVE}s1a
 
 gpart set -a active -i 1 ${NANO_DRIVE}
+#
+# KD - If the partition has an EFI partition then set "loader.env"
+#
+EFI=`gpart show ${NANO_DRIVE}|grep 'efi'`
+if [ $EFI != '' ] ;
+then
+	PART=`echo $EFI|awk '{ print $3 }'`
+	mount -t msdosfs /dev/${NANO_DRIVE}s$EFI /mnt
+	echo 'rootdev=disk0s1a' >/mnt/EFI/FreeBSD/loader.env
+	umount /mnt
+fi


### PR DESCRIPTION
Concurrently with the base change to legacy.sh if we have an EFI partition set "rootdev" so the loader will boot the desired partition.

There's a fly in this ointment in that there is no way to know for sure what order the EFI loader will enumerate devices, so if there are others the device can be wrong and that prevents booting - - and there is no way to know what it did from the running system (I've got an example system here that has this problem.)  Thus care has to be taken using this, which is unfortunate.